### PR TITLE
Remove deprecated `bottle :unneeded`

### DIFF
--- a/otel-cli.rb
+++ b/otel-cli.rb
@@ -7,7 +7,6 @@ class OtelCli < Formula
   homepage "https://github.com/equinix-labs/otel-cli"
   version "0.0.19"
   license "Apache-2.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Homebrew prints a warning since quite a while:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the equinix-labs/otel-cli tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/equinix-labs/homebrew-otel-cli/otel-cli.rb:10
```

This change should fix it.